### PR TITLE
Adding a new option for the user info

### DIFF
--- a/python/intercoop/catalog.py
+++ b/python/intercoop/catalog.py
@@ -156,7 +156,12 @@ class IntercoopCatalog(object):
         fields = self.requiredFields(peer, service)
         peerData = self.peers.get(peer)
         serviceData = peerData.services[service]
-        data = self.users.getFields(user, fields)
+
+        if isinstance(user, ns):
+            data = user
+        else:
+            data = self.users.getFields(user, fields)
+
         api = apiclient.ApiClient(peerData.targetUrl, self.key)
         continuationUrl = api.activateService(service, data)
         return continuationUrl


### PR DESCRIPTION
While implementing intercoop to sommobilitat, we faced that almost every request has a different user, so it would better to instead of saving the user info to a `yaml` file, we could pass a simple namespace object, so we avoid saving the file and loading it later.

So, a simple example of how it could be used would be:

```
user = ns.loads("""
    originpeer: somillusio
    lang: es
    nif: 12345678Z
    name: Bunny, Bugs
""")
continuationUrl = self.catalog.activate(peer, service, user)
```